### PR TITLE
feat: add per-device progress bars to device list

### DIFF
--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -142,16 +142,56 @@ body {
     border-radius: 10px;
     border-left: 5px solid #667eea;
     display: flex;
+    flex-direction: column;
+    gap: 10px;
+    transition: all 0.3s ease;
+}
+
+.device-item-top {
+    display: flex;
     justify-content: space-between;
     align-items: center;
-    transition: all 0.3s ease;
     gap: 12px;
 }
 
-.device-item > div:first-child {
+.device-item-top > div:first-child {
     flex: 1 1 auto;
     min-width: 0;
     word-break: break-word;
+}
+
+.device-progress {
+    display: none;
+}
+
+.progress-bar-sm {
+    width: 100%;
+    height: 16px;
+    background: #e9ecef;
+    border-radius: 8px;
+    overflow: hidden;
+}
+
+.progress-fill-sm {
+    height: 100%;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    color: white;
+    font-size: 0.7em;
+    line-height: 16px;
+    text-align: center;
+    transition: width 0.3s ease;
+    white-space: nowrap;
+}
+
+.progress-label {
+    display: block;
+    font-size: 0.8em;
+    color: #6c757d;
+    margin-top: 4px;
+}
+
+.progress-speed:empty {
+    display: none;
 }
 
 .device-item:hover {
@@ -189,6 +229,8 @@ body {
 @media (max-width: 480px) {
     .device-item {
         padding: 12px 14px;
+    }
+    .device-item-top {
         flex-wrap: wrap;
     }
     .device-send-btn {

--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -20,7 +20,7 @@ const sendHint = document.getElementById('sendHint');
 const clearFilesBtn = document.getElementById('clearFilesBtn');
 
 const refreshDeviceList = () => {
-    UI.updateDeviceList(latestDevices, currentDeviceId, sendToDevice, selectedFiles.length > 0);
+    UI.updateDeviceList(latestDevices, currentDeviceId, sendToDevice, selectedFiles.length > 0, WebRTCService.isTransferring);
 };
 
 const onFilesSelected = (files) => {
@@ -83,6 +83,9 @@ const sendToDevice = (targetId) => {
 
 // Make the WebRTC layer notify us when a send finishes so we can clear state.
 onTransferComplete = () => resetSelection();
+
+// Keep the device list's per-device "Sending..." state in sync with active transfers.
+onActiveTransfersChanged = () => refreshDeviceList();
 
 // --- WebSocket / device list ---
 SocketService.connect(currentDeviceId, {

--- a/src/main/resources/static/js/ui-manager.js
+++ b/src/main/resources/static/js/ui-manager.js
@@ -10,7 +10,7 @@ const UI = {
         }
     },
 
-    updateDeviceList: (devices, currentDeviceId, onSend, canSend) => {
+    updateDeviceList: (devices, currentDeviceId, onSend, canSend, isTransferring) => {
         const listDiv = document.getElementById('deviceList');
         const otherDevices = devices.filter(d => d !== currentDeviceId);
 
@@ -21,8 +21,13 @@ const UI = {
 
         listDiv.innerHTML = '';
         otherDevices.forEach(device => {
+            const transferring = isTransferring && isTransferring(device);
+
             const div = document.createElement('div');
             div.className = 'device-item';
+
+            const top = document.createElement('div');
+            top.className = 'device-item-top';
 
             const info = document.createElement('div');
 
@@ -38,35 +43,54 @@ const UI = {
 
             const sendBtn = document.createElement('button');
             sendBtn.className = 'device-send-btn';
-            sendBtn.textContent = '📤 Send';
-            sendBtn.disabled = !canSend;
-            sendBtn.title = canSend ? 'Send selected file(s)' : 'Select file(s) first';
+            sendBtn.textContent = transferring ? '⏳ Sending…' : '📤 Send';
+            sendBtn.disabled = !canSend || transferring;
+            sendBtn.title = transferring
+                ? 'Transfer in progress'
+                : (canSend ? 'Send selected file(s)' : 'Select file(s) first');
             sendBtn.onclick = (e) => {
                 e.stopPropagation();
                 onSend(device);
             };
 
-            div.appendChild(info);
-            div.appendChild(sendBtn);
+            top.appendChild(info);
+            top.appendChild(sendBtn);
+            div.appendChild(top);
+
+            const progress = document.createElement('div');
+            progress.className = 'device-progress';
+            progress.id = 'progress-' + device;
+            progress.style.display = 'none';
+            progress.innerHTML =
+                '<div class="progress-bar-sm"><div class="progress-fill-sm" id="progress-fill-' + device + '">0%</div></div>' +
+                '<span class="progress-label" id="progress-text-' + device + '"></span>' +
+                '<span class="progress-label progress-speed" id="progress-speed-' + device + '"></span>';
+            div.appendChild(progress);
+
             listDiv.appendChild(div);
         });
     },
 
-    updateProgress: (percent, text) => {
-        const fill = document.getElementById('progressFill');
-        const progressText = document.getElementById('progressText');
-        const section = document.getElementById('transferSection');
-
-        if (section) section.style.display = 'block';
+    updateProgress: (peerId, percent, text) => {
         const clamped = Math.min(Math.max(percent, 0), 100);
-        fill.style.width = clamped + '%';
-        fill.textContent = clamped + '%';
-        progressText.textContent = text;
+
+        const peerProgress = document.getElementById('progress-' + peerId);
+        if (peerProgress) {
+            const peerFill = document.getElementById('progress-fill-' + peerId);
+            const peerText = document.getElementById('progress-text-' + peerId);
+            peerProgress.style.display = 'block';
+            if (peerFill) {
+                peerFill.style.width = clamped + '%';
+                peerFill.textContent = clamped + '%';
+            }
+            if (peerText) peerText.textContent = text;
+        }
     },
 
-    hideProgress: () => {
-        const section = document.getElementById('transferSection');
-        if (section) section.style.display = 'none';
+    hideProgress: (peerId) => {
+        if (!peerId) return;
+        const peerProgress = document.getElementById('progress-' + peerId);
+        if (peerProgress) peerProgress.style.display = 'none';
     },
 
     showAlert: (message, type) => {
@@ -79,8 +103,9 @@ const UI = {
         setTimeout(() => alert.remove(), 5000);
     },
 
-    updateTransferSpeed: (bytesPerSecond) => {
-        const el = document.getElementById('transferSpeed');
+    updateTransferSpeed: (bytesPerSecond, peerId) => {
+        if (!peerId) return;
+        const el = document.getElementById('progress-speed-' + peerId);
         if (!el) return;
         el.textContent = bytesPerSecond > 0
             ? `Speed: ${UI.formatFileSize(Math.round(bytesPerSecond))}/s`

--- a/src/main/resources/static/js/webrtc-service.js
+++ b/src/main/resources/static/js/webrtc-service.js
@@ -84,12 +84,12 @@ const closeConnection = (remoteDeviceId) => {
     conn.currentChunks = [];
     connections.delete(remoteDeviceId);
 
-    // Hide the progress section if no transfer is active anymore
-    if (connections.size === 0 && typeof UI !== 'undefined' && UI.hideProgress) {
-        setTimeout(() => {
-            if (connections.size === 0) UI.hideProgress();
-        }, 3000);
+    if (typeof UI !== 'undefined' && UI.hideProgress) {
+        setTimeout(() => UI.hideProgress(remoteDeviceId), 3000);
     }
+
+    // Let the device list re-render so this peer's "Sending..." state clears.
+    if (typeof onActiveTransfersChanged === 'function') onActiveTransfersChanged();
 };
 
 const computeSpeed = (doneBytes, startTime) => {
@@ -135,7 +135,7 @@ const finishReceivingIfReady = (conn, remoteId) => {
     if (conn.batchFiles && conn.batchFiles.length > 1) {
         UI.showAlert('All ' + conn.batchFiles.length + ' files received from ' + NameGenerator.getDisplayName(remoteId), 'success');
     }
-    UI.updateTransferSpeed(0);
+    UI.updateTransferSpeed(0, remoteId);
     closeConnection(remoteId);
 };
 
@@ -145,8 +145,8 @@ const reportSendSuccess = (conn, remoteId) => {
         conn.completionTimer = null;
     }
     silenceConnectionEvents(conn);
-    UI.updateProgress(100, 'All files sent to ' + NameGenerator.getDisplayName(remoteId));
-    UI.updateTransferSpeed(0);
+    UI.updateProgress(remoteId, 100, 'All files sent to ' + NameGenerator.getDisplayName(remoteId));
+    UI.updateTransferSpeed(0, remoteId);
     UI.showAlert('All files sent to ' + NameGenerator.getDisplayName(remoteId), 'success');
     setTimeout(() => closeConnection(remoteId), 1000);
     if (typeof onTransferComplete === 'function') onTransferComplete();
@@ -327,7 +327,7 @@ const sendNextFile = (conn, remoteId) => {
     if (conn.aborted) return;
     if (conn.fileIndex >= conn.files.length) {
         trySendMessage(conn.dataChannel, { type: 'done' });
-        UI.updateProgress(100, 'Finishing transfer to ' + NameGenerator.getDisplayName(remoteId) + '…');
+        UI.updateProgress(remoteId, 100, 'Finishing transfer to ' + NameGenerator.getDisplayName(remoteId) + '…');
 
         // Detach state/error handlers now: a brief ICE 'failed' during normal
         // teardown is expected from this point on and must not surface as a
@@ -481,10 +481,11 @@ const handleIncomingMessage = (conn, remoteId, data) => {
         const label = formatFileLabel(conn.currentFile.name, idx, total);
 
         UI.updateProgress(
+            remoteId,
             overallPercent,
             `Receiving ${label}: ${UI.formatFileSize(conn.currentReceived)} / ${UI.formatFileSize(expected)}`
         );
-        UI.updateTransferSpeed(computeSpeed(conn.totalDoneBytes, conn.transferStartTime));
+        UI.updateTransferSpeed(computeSpeed(conn.totalDoneBytes, conn.transferStartTime), remoteId);
     }
 
     if (!isLastChunk) {
@@ -518,7 +519,7 @@ const finalizeReceivedFile = async (remoteId, fileMeta, chunks, isOnlyFile) => {
     const blob = new Blob(chunks);
 
     if (fileMeta.hash) {
-        UI.updateProgress(100, 'Verifying ' + fileMeta.name + '…');
+        UI.updateProgress(remoteId, 100, 'Verifying ' + fileMeta.name + '…');
         const ok = await verifyBlobHash(blob, fileMeta.hash);
         if (!ok) {
             UI.showAlert('Integrity check FAILED for ' + fileMeta.name + ' — file dropped.', 'error');
@@ -555,6 +556,7 @@ const WebRTCService = {
         const conn = newConnectionState();
         conn.files = files;
         connections.set(targetId, conn);
+        if (typeof onActiveTransfersChanged === 'function') onActiveTransfersChanged();
 
         try {
             conn.peerConnection = new RTCPeerConnection({ iceServers: ICE_SERVERS });
@@ -621,19 +623,21 @@ const WebRTCService = {
                     const label = formatFileLabel(file.name, conn.fileIndex + 1, conn.files.length);
 
                     UI.updateProgress(
+                        targetId,
                         percent,
                         `Sending ${label}: ${UI.formatFileSize(doneBytes)} / ${UI.formatFileSize(conn.totalBytes)}`
                     );
-                    UI.updateTransferSpeed(computeSpeed(doneBytes, conn.transferStartTime));
+                    UI.updateTransferSpeed(computeSpeed(doneBytes, conn.transferStartTime), targetId);
                 }
             };
 
             // Hash each file (with timeout so iOS Photos lazy-load can't hang us)
-            UI.updateProgress(0, `Preparing ${files.length} file${files.length > 1 ? 's' : ''}…`);
+            UI.updateProgress(targetId, 0, `Preparing ${files.length} file${files.length > 1 ? 's' : ''}…`);
             conn.fileMetas = [];
             for (let i = 0; i < files.length; i++) {
                 const f = files[i];
                 UI.updateProgress(
+                    targetId,
                     Math.round((i / files.length) * 100),
                     `Hashing (${i + 1}/${files.length}): ${f.name}`
                 );
@@ -644,7 +648,7 @@ const WebRTCService = {
             const offer = await conn.peerConnection.createOffer();
             await conn.peerConnection.setLocalDescription(offer);
 
-            UI.updateProgress(0, 'Waiting for ' + NameGenerator.getDisplayName(targetId) + ' to accept…');
+            UI.updateProgress(targetId, 0, 'Waiting for ' + NameGenerator.getDisplayName(targetId) + ' to accept…');
 
             // Give up if receiver never accepts/connects (data channel open AND
             // ICE stable) in time.
@@ -711,7 +715,7 @@ const WebRTCService = {
             const conn = connections.get(remoteId);
             if (conn) {
                 UI.showAlert(NameGenerator.getDisplayName(remoteId) + ' declined the transfer.', 'info');
-                UI.updateTransferSpeed(0);
+                UI.updateTransferSpeed(0, remoteId);
                 closeConnection(remoteId);
             }
             return;
@@ -732,7 +736,7 @@ const WebRTCService = {
                     }
                 }
                 conn.pendingCandidates = [];
-                UI.updateProgress(0, 'Receiver accepted — establishing connection…');
+                UI.updateProgress(remoteId, 0, 'Receiver accepted — establishing connection…');
             } catch (err) {
                 UI.showAlert('Connection error: ' + err.message, 'error');
                 closeConnection(remoteId);
@@ -758,6 +762,7 @@ const WebRTCService = {
         if (!conn) {
             conn = newConnectionState();
             connections.set(remoteId, conn);
+            if (typeof onActiveTransfersChanged === 'function') onActiveTransfersChanged();
         }
         conn.batchFiles = files;
         conn.totalBytes = files.reduce((s, f) => s + (f.size || 0), 0);
@@ -817,9 +822,14 @@ const WebRTCService = {
 
     activeTransfers: () => connections.size,
 
+    isTransferring: (peerId) => connections.has(peerId),
+
     cancelAll: () => {
         for (const id of Array.from(connections.keys())) closeConnection(id);
     }
 };
 
 let onTransferComplete = null;
+// Notified whenever a connection is opened or closed, so the UI can refresh
+// per-device "Sending..." state without waiting for the next device-list broadcast.
+let onActiveTransfersChanged = null;

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -58,19 +58,6 @@
             </p>
         </div>
 
-        <div class="section" id="transferSection" style="display:none;">
-            <h2>📊 Transfer Status</h2>
-            <div class="progress-container" id="progressContainer" style="display:block;">
-                <div class="progress-bar">
-                    <div class="progress-fill" id="progressFill">0%</div>
-                </div>
-                <p style="text-align: center; margin-top: 10px; color: #6c757d;">
-                    <span id="progressText">Preparing...</span>
-                </p>
-                <p class="transfer-speed" id="transferSpeed"></p>
-            </div>
-        </div>
-
         <div class="section">
             <h2>🌐 Connected Devices</h2>
             <div id="deviceList">


### PR DESCRIPTION
## Summary
- Re-adds the per-device transfer progress UI that was lost during the `develop` merge conflict resolution (PR #9), adapted to the current multi-file batch / hash-verification architecture instead of the old single-file design.
- Removes the shared "Transfer Status" section; each device item in the list now shows its own progress bar, status text, and transfer speed.
- The Send button now switches to a disabled "⏳ Sending…" state immediately when a transfer to that device starts, and reverts immediately when it ends, via a new `onActiveTransfersChanged` hook.

## Changes
- `webrtc-service.js`: added `WebRTCService.isTransferring(peerId)`; all `UI.updateProgress`/`UI.updateTransferSpeed` calls now target a specific peer; added `onActiveTransfersChanged` hook fired on connection open/close.
- `ui-manager.js`: `updateDeviceList` renders a per-device mini progress bar + speed label and reflects transfer state on the Send button; `updateProgress`/`updateTransferSpeed`/`hideProgress` are now per-peer only.
- `app.js`: wires `onActiveTransfersChanged` to `refreshDeviceList`, and passes `WebRTCService.isTransferring` to `updateDeviceList`.
- `style.css`: restructured `.device-item` into a column layout with a new `.device-progress`/`.progress-bar-sm`/`.progress-fill-sm`/`.progress-label` per-device progress bar.
- `index.html`: removed the global "Transfer Status" section.

Related to #10