### PR TITLE
ci: bump GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -15,10 +15,10 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -29,7 +29,7 @@ jobs:
         run: mvn clean verify
 
       - name: Upload Jacoco Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: jacoco-report
           path: target/site/jacoco/
@@ -45,7 +45,7 @@ jobs:
 
       - name: Login to GHCR
         if: github.ref == 'refs/heads/master'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -53,7 +53,7 @@ jobs:
 
       - name: Build and Push Docker Image
         if: github.ref == 'refs/heads/master'
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true


### PR DESCRIPTION
## Summary
Syncs develop into master.

Bumps GitHub Actions in `pipeline.yml` to Node.js 24-compatible major versions ahead of the 2026-06-16 forced-Node-24 deadline:
- `actions/checkout`: v4 → v6
- `actions/setup-java`: v4 → v5
- `actions/upload-artifact`: v4 → v7
- `docker/login-action`: v3 → v4
- `docker/build-push-action`: v5 → v7

No behavioral changes — same inputs/outputs for these major versions.